### PR TITLE
fix: fix document example type error

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ const UserProvider = (): HttpMiddleware => {
 
 const http = Http()
 
-http.use(UserProvider)
+http.use(UserProvider())
 
 http
   .match({


### PR DESCRIPTION
fix example type error. It will cause :

```typescript
TS2345: Argument of type '() => HttpMiddleware' is not assignable to parameter of type 'MiddlewareInput<RequestInfo, MaybeAsync<Response>>'.   Type '() => HttpMiddleware' is not assignable to type 'Middleware<RequestInfo, MaybeAsync<Response>>'.     Type 'Middleware<RequestInfo, MaybeAsyncResponse>' is not assignable to type 'MaybeAsync<Response>'.       Type 'Middleware<RequestInfo, MaybeAsyncResponse>' is missing the following properties from type 'Promise<Response>': then, catch, [Symbol.toStringTag], finally
```