### PR TITLE
fix: fix document example error

### DIFF
--- a/docs/cors.md
+++ b/docs/cors.md
@@ -206,7 +206,10 @@ You can also enable pre-flight across-the-board like so:
 // include before other routes
 http
   .match({
-    pathname: '*',
+    // we can not simple use wildcard here
+    // because Path-To-RegExp breaks compatibility
+    // https://github.com/pillarjs/path-to-regexp#compatibility-with-express--4x
+    pathname: '(.*)',
     method: 'OPTIONS',
   })
   .use(cors())


### PR DESCRIPTION
the wildcard has been disabled by Path-To-Regexp and use wildcard in pathname will cause error:

```
 throw new TypeError("Unexpected " + nextType + " at " + index + ", expected " + type);
      ^

TypeError: Unexpected MODIFIER at 1, expected END

```

We can use (.*) by https://github.com/pillarjs/path-to-regexp#compatibility-with-express--4x