### PR TITLE
docs: fix typo

### DIFF
--- a/packages/example/README.md
+++ b/packages/example/README.md
@@ -1,6 +1,6 @@
 # farrow-example
 
-An **todo-list** example for farrow-http
+A **todo-list** example for farrow-http.
 
 ```shell
 # for developing


### PR DESCRIPTION
Fix a typo in farrow-example's readme.