### PR TITLE
fix: bootstrap command should install lerna first

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format:source": "prettier ./**/*.{ts,tsx,js} --write",
     "test": "jest",
     "test:coverage": "jest --collectCoverage --coverage",
-    "bootstrap": "lerna bootstrap --hoist",
+    "bootstrap": "npm i && lerna bootstrap --hoist",
     "release": "lerna publish",
     "prerelease": "npm run build && npm run test"
   },


### PR DESCRIPTION
If user hasn't run "npm i" after clone, there could be an error "lerna: command not found", if no lerna is globally installed. 
Hence the "npm i" is added before lerna.