### PR TITLE
fix: node.js of 12.x doesn't support require('fs/promise')

### DIFF
--- a/packages/farrow-api/src/__tests__/codegen.test.ts
+++ b/packages/farrow-api/src/__tests__/codegen.test.ts
@@ -1,4 +1,4 @@
-import fs from 'fs/promises'
+import fsm from 'fs'
 import { Api } from '../api'
 import { toJSON } from '../toJSON'
 import { codegen } from '../codegen'
@@ -20,6 +20,8 @@ import {
   Union,
   Unknown,
 } from 'farrow-schema'
+
+const fs = fsm.promises
 
 class Collection extends ObjectType {
   number = Number

--- a/packages/farrow-vite/src/vite.ts
+++ b/packages/farrow-vite/src/vite.ts
@@ -1,8 +1,10 @@
 import path from 'path'
-import fs from 'fs/promises'
+import fsm from 'fs'
 import type { IncomingMessage, ServerResponse } from 'http'
 import { Response, Router } from 'farrow-http'
 import { createServer as createViteServer, InlineConfig } from 'vite'
+
+const fs = fsm.promises
 
 export const vite = (options?: InlineConfig) => {
   let router = Router()

--- a/packages/farrow/src/api-client/index.ts
+++ b/packages/farrow/src/api-client/index.ts
@@ -1,10 +1,12 @@
-import fs from 'fs/promises'
+import fsm from 'fs'
 import { ensureDir } from 'fs-extra'
 import { dirname } from 'path'
 import fetch from 'node-fetch'
 import { FormatResult } from 'farrow-api/dist/toJSON'
 import { codegen, CodegenOptions } from 'farrow-api/dist/codegen'
 import { format } from 'farrow-api/dist/prettier'
+
+const fs = fsm.promises
 
 const writeFile = async (filename: string, content: string) => {
   try {

--- a/packages/farrow/src/bundler/server.ts
+++ b/packages/farrow/src/bundler/server.ts
@@ -2,12 +2,14 @@ import path from 'path'
 import execa, { ExecaChildProcess } from 'execa'
 import { Plugin, startService, BuildOptions } from 'esbuild'
 import slash from 'slash'
-import fs from 'fs/promises'
+import fsm from 'fs'
 import readPkgUp from 'read-pkg-up'
 
 import { watchFiles } from '../util/watchFiles'
 import { join } from '../util/join'
 import { memo } from '../util/memo'
+
+const fs = fsm.promises
 
 export type BundlerOptions = {
   /**


### PR DESCRIPTION
https://stackoverflow.com/questions/64725249/fs-promises-api-in-typescript-not-compiling-in-javascript-correctly